### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Redis MCP Server
+[![smithery badge](https://smithery.ai/badge/redis-mcp)](https://smithery.ai/server/redis-mcp)
 
 A Model Context Protocol (MCP) server that provides access to Redis database operations.
 
@@ -63,6 +64,14 @@ Configure in your MCP client (e.g., Claude Desktop, Cline):
 
 - `--redis-host`: Redis server host (default: localhost)
 - `--redis-port`: Redis server port (default: 6379)
+
+### Installing via Smithery
+
+To install Redis Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/redis-mcp):
+
+```bash
+npx -y @smithery/cli install redis-mcp --client claude
+```
 
 ## Development
 


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds installation instructions to automatically install Redis Server for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP.
2. Adds a badge to show the number of installations from Smithery: https://smithery.ai/server/redis-mcp

Let me know if any tweaks have to be made!